### PR TITLE
[Pibbble][#108851964] Remove white space above dashboard image

### DIFF
--- a/public/css/dashboard.css
+++ b/public/css/dashboard.css
@@ -99,7 +99,7 @@ body {
 }
 
 .ball .well-sm {
-    margin-top: -11px;
+    margin-top: 0px;
     padding: 9px;
     border-radius: 3px;
 }


### PR DESCRIPTION
Removed the white space above the background image on the dashboard.
