### PR TITLE
[Feature #111889695] Add number of comments + comment icon to grid

### DIFF
--- a/resources/views/others/projects_grid.blade.php
+++ b/resources/views/others/projects_grid.blade.php
@@ -12,6 +12,7 @@
         <div class='projects'>
             <!-- Trigger modal window when a project thumbnail is clicked -->
             <a href="" data-toggle="modal" data-target="#{{ $project->id }}" onclick="view({{ $project->id }}, '{{ $viewsValueOnThumbnail }}', '{{ $viewsValueOnModal }}')"><img src='{{ $project->image_url }}' width='200' height='150' /></a>
+            <span class='project-stats'><i class='fa fa-comment-o'> {{ count($project->comments) }}</i></span>
             <span id="{{ $likesValueOnThumbnail }}" class='project-stats'><i class='fa fa-thumbs-o-up'></i>&nbsp;{{ $project->projectLikes->count() }}</span>
             <span class='project-stats'><i class='fa fa-eye'></i>&nbsp;<span id="{{ $viewsValueOnThumbnail }}">{{ $project->views }}</span></span>
         </div>


### PR DESCRIPTION
Every project on the projects grid now displays the number of
comments and a comment icon, alongside the views and likes.
