### PR TITLE
[Chore #112349171] Font for number of comments on the projects grid should be made uniform with other fonts.

### DIFF
--- a/resources/views/others/projects_grid.blade.php
+++ b/resources/views/others/projects_grid.blade.php
@@ -12,7 +12,10 @@
         <div class='projects'>
             <!-- Trigger modal window when a project thumbnail is clicked -->
             <a href="" data-toggle="modal" data-target="#{{ $project->id }}" onclick="view({{ $project->id }}, '{{ $viewsValueOnThumbnail }}', '{{ $viewsValueOnModal }}')"><img src='{{ $project->image_url }}' width='200' height='150' /></a>
-            <span class='project-stats'><i class='fa fa-comment-o'> {{ count($project->comments) }}</i></span>
+            <span class='project-stats'>
+                <i class='fa fa-comment-o'></i>
+                <span id='comments-project-{{ $project->id }}'>{{ count($project->comments) }}</span>
+            </span>
             <span id="{{ $likesValueOnThumbnail }}" class='project-stats'><i class='fa fa-thumbs-o-up'></i>&nbsp;{{ $project->projectLikes->count() }}</span>
             <span class='project-stats'><i class='fa fa-eye'></i>&nbsp;<span id="{{ $viewsValueOnThumbnail }}">{{ $project->views }}</span></span>
         </div>


### PR DESCRIPTION
After adding the feature (issue #260) where the number of comments are displayed on the projects grid, the fonts for the comments were found not to be uniform with the rest of the page. This fixes that by removing
the text from within the italics tags.

I also added an id attribute (id='comments-project-{{ $project->id }}') to the span where the number of comments will be displayed, both because it will make it easier to resolve issue [#297](https://github.com/andela/pibbble/issues/297), and it makes it easier, in general, to deal with these elements that need to be manipulated instead of doing DOM acrobatics, since their values are not constant.
