### PR TITLE
[Bug #112351123] Fix number of responses displayed to the user immediately upon commenting

### DIFF
--- a/app/Helpers/PostComment.php
+++ b/app/Helpers/PostComment.php
@@ -43,6 +43,7 @@ class PostComment
                 'comment' => $request->comment,
                 'comment_id' => $commentId,
                 'commentTime' => $commentRepo->getCommentTime($commentId),
+                'commentCount' => $project->comment_count,
         ];
     }
 }

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -142,13 +142,16 @@ var makeComment = function(evt){
 
           if(lastComment.length < 1){
             newComment =
-              '<div><h4>1 Responses</h4>'
+              '<div><h4>1 Response</h4>'
             + newComment
             + '</div>';
             form.parent().prev().after(newComment);
+            document.getElementById("comments-project-" + respData.project_id).innerHTML = 1;
           }
           else {
             lastComment.after(newComment);
+            form.parent().parent().find('h4').text(respData.commentCount + " Responses");
+            document.getElementById("comments-project-" + respData.project_id).innerHTML = respData.commentCount;
           }
           comment.val('');
         }

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -146,12 +146,15 @@ var makeComment = function(evt){
             + newComment
             + '</div>';
             form.parent().prev().after(newComment);
-            document.getElementById("comments-project-" + respData.project_id).innerHTML = 1;
+            document.getElementById('comments-project-' + respData.project_id)
+              .innerHTML = 1;
           }
           else {
             lastComment.after(newComment);
-            form.parent().parent().find('h4').text(respData.commentCount + " Responses");
-            document.getElementById("comments-project-" + respData.project_id).innerHTML = respData.commentCount;
+            form.parent().parent().find('h4')
+              .text(respData.commentCount + ' Responses');
+            document.getElementById('comments-project-' + respData.project_id)
+              .innerHTML = respData.commentCount;
           }
           comment.val('');
         }


### PR DESCRIPTION
This patch fixes the issue when a user comments on a project,
but the number of responses is not immediately updated, while the
comments themselves are saved and updated on the page.

The update is now immediate within the modal and the grid.
