### PR TITLE
[Fixes #112402959] Fixes bug on updating a user setting with empty parameters

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -47,7 +47,7 @@ class ProfileController extends Controller
         $input = $request->except('_token', 'url');
 
         $this->validate($request, [
-            'username' => 'required|unique:users'
+            'username' => 'required|unique:users,username,'.Auth::user()->id
         ]);
 
         User::find(Auth::user()->id)->updateProfile($input);

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -45,6 +45,11 @@ class ProfileController extends Controller
     public function updateProfileSettings(Request $request)
     {
         $input = $request->except('_token', 'url');
+
+        $this->validate($request, [
+            'username' => 'required|unique:users'
+        ]);
+
         User::find(Auth::user()->id)->updateProfile($input);
 
         return redirect('/settings/profile')->with('status', 'You have successfully updated your profile.');

--- a/app/User.php
+++ b/app/User.php
@@ -77,9 +77,7 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
     public function updateProfile($formData)
     {
         foreach ($formData as $key => $value) {
-            if (! empty($value)) {
-                $this->$key = $value;
-            }
+            $this->$key = $value;
         }
 
         $this->save();

--- a/resources/views/profile/settings.blade.php
+++ b/resources/views/profile/settings.blade.php
@@ -27,7 +27,7 @@
                 <div class="form-group">
                     <label class="col-sm-2 control-label">Username</label>
                     <div class="col-sm-5">
-                        <input type="text" name="username" class="form-control" value="{{ Auth::user()->username }}">
+                        <input type="text" name="username" class="form-control" value="{{ Auth::user()->username }}" required>
                     </div>
                 </div>
                 <div class="form-group">

--- a/resources/views/profile/settings.blade.php
+++ b/resources/views/profile/settings.blade.php
@@ -10,6 +10,16 @@
     @endif
 </div>
 
+@if (count($errors) > 0)
+    <div class="alert alert-danger" style="text-align: center; margin-top: -20px;">
+        <ul style="list-style:none;">
+            @foreach ($errors->all() as $error)
+                <li>{{ $error }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif
+
 <h3 class="tab-bar" style="text-align: center;"><strong>Update your profile settings</strong></h3>
 
 <hr>


### PR DESCRIPTION
The update `post` route was only checking for non-empty parameters, so it was not updating them, even if that was the intention of the user. I have updated it to work with empty parameters, and added a validation rule on the `username`, since it is the one that is `required`, and must be `unique`.
