### PR TITLE
[Feature #111404476] developer project details page

### DIFF
--- a/app/Http/Controllers/PagesController.php
+++ b/app/Http/Controllers/PagesController.php
@@ -2,6 +2,7 @@
 
 namespace Pibbble\Http\Controllers;
 
+use Pibbble\User;
 use Carbon\Carbon;
 use Pibbble\Project;
 use Pibbble\ProjectLikes;
@@ -118,10 +119,12 @@ class PagesController extends Controller
         return view('developers', ['users' => $users]);
     }
 
-    public function developerProject()
+    public function developerProject($param)
     {
-        // $project = Project::where('id', '=', 7)->get();
-        // $project = Project::where('id', 7)->first();
-        // return view('project_details', ['project' => $project]);
+        $id = explode('-', $param)[0];
+
+        $project = Project::where('id', $id)->first();
+
+        return view('project_details', ['project' => $project]);
     }
 }

--- a/resources/views/developers.blade.php
+++ b/resources/views/developers.blade.php
@@ -22,7 +22,7 @@
                         {{ $user->location }}<br />
                         {{ $user->skills }}<br />
                          <div class="l-separator"><b>{{ $user->projects->count() }}</b><br />projects</div>
-                         <div class="r-separator"><b>?</b><br />followers</div>
+                         <div class="r-separator"><b>{{ $user->followers()->count() }}</b><br />followers</div>
                     </div>
                     <div class="dev-projs">
                         @foreach($user->projects as $project)

--- a/resources/views/project_details.blade.php
+++ b/resources/views/project_details.blade.php
@@ -5,13 +5,7 @@
     <script src="{{ load_asset('/js/like.js') }}"></script>
     <script src="{{ load_asset('/js/view.js') }}"></script>
 
-    <?php
-        $likesValueOnThumbnail = 'proj_'.$project->id.'_thumb_likes';
-        $likesValueOnModal = 'proj_'.$project->id.'_modal_likes';
-        $modalLikesLink = 'proj_'.$project->id.'_modal_like_link';
-        $viewsValueOnThumbnail = 'proj_'.$project->id.'_thumb_views';
-        $viewsValueOnModal = 'proj_'.$project->id.'_modal_views';
-    ?>
+    @include('shared.project_details_vars')
 
     <div class="fade-lg" id="{{ $project->id }}" role="dialog">
         <div class="container-fluid">
@@ -19,7 +13,6 @@
             <div class="col-sm-2"></div>
             <div class="col-sm-9" style="border: 0px solid gray;">
                 <div class="modal-header">
-                    <!-- <button type="button" class="close" data-dismiss="modal">&times;</button> -->
                     <br />
                     <h3 class="modal-title">{{ $project->projectname }}</h3>
                     <p>by <a href="{{ route('userprofile', $project->user->username) }}" class="no-decoration">{{ $project->user->username }}</a></p>
@@ -38,7 +31,7 @@
                                     <i class='fa fa-thumbs-o-up'></i>&nbsp;{{ $project->projectLikes->count() }}&nbsp;Likes
                                 @endif
                             </p>
-                            <p><i class='fa fa-eye'></i>&nbsp;<span id="{{ $viewsValueOnModal }}">{{ $project->views }}</span>&nbsp;Views</p>
+                            <p><i class='fa fa-eye'></i>&nbsp;<span>{{ $project->views }}</span>&nbsp;Views</p>
                         </div>
                     </div>
                     <br clear="left">
@@ -76,9 +69,6 @@
                         </form>
                     </div>
                 @endcan
-                <!-- <div class="modal-footer">
-                    <button type="button" class="btn btn-info" data-dismiss="modal">Close</button>
-                </div> -->
             </div>
             <div class="col-sm-1"></div>
             </div>

--- a/resources/views/project_details.blade.php
+++ b/resources/views/project_details.blade.php
@@ -1,9 +1,10 @@
-<?php //dd($project); ?>
-
 @extends('layouts.master')
-@section('title', 'Developers')
+@section('title', 'Developer Project')
 
 @section('content')
+    <script src="{{ load_asset('/js/like.js') }}"></script>
+    <script src="{{ load_asset('/js/view.js') }}"></script>
+
     <?php
         $likesValueOnThumbnail = 'proj_'.$project->id.'_thumb_likes';
         $likesValueOnModal = 'proj_'.$project->id.'_modal_likes';
@@ -12,11 +13,13 @@
         $viewsValueOnModal = 'proj_'.$project->id.'_modal_views';
     ?>
 
-    <div class="modal fade-lg" id="{{ $project->id }}" role="dialog">
-        <div class="modal-dialog modal-lg">
-            <div class="modal-content">
+    <div class="fade-lg" id="{{ $project->id }}" role="dialog">
+        <div class="container-fluid">
+            <div class="row">
+            <div class="col-sm-2"></div>
+            <div class="col-sm-9" style="border: 0px solid gray;">
                 <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal">&times;</button>
+                    <!-- <button type="button" class="close" data-dismiss="modal">&times;</button> -->
                     <br />
                     <h3 class="modal-title">{{ $project->projectname }}</h3>
                     <p>by <a href="{{ route('userprofile', $project->user->username) }}" class="no-decoration">{{ $project->user->username }}</a></p>
@@ -73,9 +76,11 @@
                         </form>
                     </div>
                 @endcan
-                <div class="modal-footer">
+                <!-- <div class="modal-footer">
                     <button type="button" class="btn btn-info" data-dismiss="modal">Close</button>
-                </div>
+                </div> -->
+            </div>
+            <div class="col-sm-1"></div>
             </div>
         </div>
     </div>

--- a/resources/views/shared/project_details_vars.blade.php
+++ b/resources/views/shared/project_details_vars.blade.php
@@ -1,0 +1,7 @@
+<?php
+    $likesValueOnThumbnail = 'proj_'.$project->id.'_thumb_likes';
+    $likesValueOnModal = 'proj_'.$project->id.'_modal_likes';
+    $modalLikesLink = 'proj_'.$project->id.'_modal_like_link';
+    $viewsValueOnThumbnail = 'proj_'.$project->id.'_thumb_views';
+    $viewsValueOnModal = 'proj_'.$project->id.'_modal_views';
+?>


### PR DESCRIPTION
I'm done with this feature. The number of followers for each developer should now be visible on the developers' list page.

Also I have finished the project details page. This is the page a user sees when he/she clicks a project's thumbnail on the developers' list page.
