### PR TITLE
[Fix #111404476] undefined variable in project details view

### DIFF
--- a/public/js/like.js
+++ b/public/js/like.js
@@ -1,4 +1,4 @@
-function like(projectID, count, likesValueOnModal, likesValueOnThumbnail, modalLikesLink)
+function like(projectID, count, likesValueOnModal, likesValueOnThumbnail, likeLink)
 {
     if (window.XMLHttpRequest) {
         xmlhttp = new XMLHttpRequest();
@@ -13,9 +13,9 @@ function like(projectID, count, likesValueOnModal, likesValueOnThumbnail, modalL
             document.getElementById(likesValueOnModal).innerHTML = likesCount;
 
             if (likesCount <= count) {
-                document.getElementById(modalLikesLink).style.color = "#999";
+                document.getElementById(likeLink).style.color = "#999";
             } else {
-                document.getElementById(modalLikesLink).style.color = "#2296cc";
+                document.getElementById(likeLink).style.color = "#2296cc";
             }
         }
     };

--- a/resources/views/project_details.blade.php
+++ b/resources/views/project_details.blade.php
@@ -5,8 +5,6 @@
     <script src="{{ load_asset('/js/like.js') }}"></script>
     <script src="{{ load_asset('/js/view.js') }}"></script>
 
-    @include('shared.project_details_vars')
-
     <div class="fade-lg" id="{{ $project->id }}" role="dialog">
         <div class="container-fluid">
             <div class="row">
@@ -23,9 +21,9 @@
                         <div class="modal-right">
                             <p>
                                 @if(Auth::user())
-                                    <a href="#" id="{{ $modalLikesLink }}" onclick="like({{ $project->id }}, {{ $project->projectLikes->count() }}, '{{ $likesValueOnModal }}', '{{ $likesValueOnThumbnail }}', '{{ $modalLikesLink }}');">
+                                    <a href="#" id="{{ 'like_link_'.$project->id }}" onclick="like({{ $project->id }}, {{ $project->projectLikes->count() }}, '{{ 'modal_likes_'.$project->id }}', '', '{{ 'like_link_'.$project->id }}');">
                                         <i class='fa fa-thumbs-o-up'></i>
-                                        <span id="{{ $likesValueOnModal }}">{{ $project->projectLikes->count() }}</span>&nbsp;Likes
+                                        <span id="{{ 'modal_likes_'.$project->id }}">{{ $project->projectLikes->count() }}</span>&nbsp;Likes
                                     </a>
                                 @else
                                     <i class='fa fa-thumbs-o-up'></i>&nbsp;{{ $project->projectLikes->count() }}&nbsp;Likes

--- a/resources/views/shared/project_details_vars.blade.php
+++ b/resources/views/shared/project_details_vars.blade.php
@@ -1,7 +1,0 @@
-<?php
-    $likesValueOnThumbnail = 'proj_'.$project->id.'_thumb_likes';
-    $likesValueOnModal = 'proj_'.$project->id.'_modal_likes';
-    $modalLikesLink = 'proj_'.$project->id.'_modal_like_link';
-    $viewsValueOnThumbnail = 'proj_'.$project->id.'_thumb_views';
-    $viewsValueOnModal = 'proj_'.$project->id.'_modal_views';
-?>


### PR DESCRIPTION
I have removed those variable declarations and instead used the values directly where i need them in the view. So the project details page should no longer give errors.
